### PR TITLE
Revised the active space selection tutorial

### DIFF
--- a/6_dynamics/2_nbra_workflows/17_active_space_selection/tutorial.ipynb
+++ b/6_dynamics/2_nbra_workflows/17_active_space_selection/tutorial.ipynb
@@ -166,7 +166,10 @@
     "\n",
     "Similar to what we had in [step 3](../8_step3), we will build the excited states basis. If we don't select all the orbitals in one band that are more probable to cross each other, the state-tracking algorithm will not be able to track the states properly and will result in sudden jump errors when doing nonadiabatic dynamics. \n",
     "\n",
-    "If we select the orbitals in a band by `num_occ_orbitals: 6` (at this point we only want to check the ground state so doesn't matter what is the selection of unoccupied orbtitals and we keep it at 5), and plot the time-overlap of the ground state with itself (the first diagonal element of the time-overlap matrix). We see that the magnitudes are very close to 1.0 which is desired for the ground state and will not result in sudden jumps. \n"
+    "If we select the orbitals in a band by `num_occ_orbitals: 6` (at this point we only want to check the ground state so doesn't matter what is the selection of unoccupied orbtitals and we keep it at 5), and plot the time-overlap of the ground state with itself (the first diagonal element of the time-overlap matrix). We see that the magnitudes are very close to 1.0 which is desired for the ground state and will not result in sudden jumps. \n",
+    "\n",
+    "We now will use the function `limit_active_space` from `step3` module. This function will limit the active space to the number \n",
+    "of occupied and unoccupied orbitals, `num_occ_orbitals` and `num_unocc_orbitals` respectively, user defines according to the above observation. The newly generated files will be saved in the `path_to_save_npz_files`. "
    ]
   },
   {

--- a/6_dynamics/2_nbra_workflows/17_active_space_selection/tutorial.ipynb
+++ b/6_dynamics/2_nbra_workflows/17_active_space_selection/tutorial.ipynb
@@ -10,7 +10,7 @@
     "In this tutorial, we show how the selection of active space should be performed. Here, we select a short snapshot \n",
     "of the $C_{20}$ fullerene structure where its molecular orbitals show a band like structure. We will show how the selection of \n",
     "the `lowest_orbital` and `highest_orbital` variables in step 2 can affect the results of the time-overlap matrix elements. \n",
-    "We only generate the single-particle basis but the results are extendible to many-body basis as well. This can lead to **sudden jumps** or faster population transfer dynamics and unphysical results. \n",
+    "We show this in the many-body basis. This can lead to **sudden jumps** or faster population transfer dynamics and unphysical results. \n",
     "\n",
     "\n",
     "## Table of contents\n",
@@ -61,7 +61,7 @@
     "import libra_py.workflows.nbra.decoherence_times as decoherence_times\n",
     "\n",
     "from recipes import fssh_nbra\n",
-    "# from recipes import dish_nbra, fssh_nbra, fssh2_nbra, gfsh_nbra, ida_nbra, mash_nbra, msdm_nbra\n"
+    "# from recipes import dish_nbra, fssh_nbra, fssh2_nbra, gfsh_nbra, ida_nbra, mash_nbra, msdm_nbra"
    ]
   },
   {
@@ -166,23 +166,56 @@
     "\n",
     "Similar to what we had in [step 3](../8_step3), we will build the excited states basis. If we don't select all the orbitals in one band that are more probable to cross each other, the state-tracking algorithm will not be able to track the states properly and will result in sudden jump errors when doing nonadiabatic dynamics. \n",
     "\n",
-    "If we select the orbitals in a band by `num_occ_states: 6` (at this point we only want to check the ground state so doesn't matter what is the selection of unoccupied orbtitals and we keep it at 5), and plot the time-overlap of the ground state with itself (the first diagonal element of the time-overlap matrix). We see that the magnitudes are very close to 1.0 which is desired for the ground state and will not result in sudden jumps. \n"
+    "If we select the orbitals in a band by `num_occ_orbitals: 6` (at this point we only want to check the ground state so doesn't matter what is the selection of unoccupied orbtitals and we keep it at 5), and plot the time-overlap of the ground state with itself (the first diagonal element of the time-overlap matrix). We see that the magnitudes are very close to 1.0 which is desired for the ground state and will not result in sudden jumps. \n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "49f6103c",
-   "metadata": {
-    "scrolled": true
-   },
+   "id": "a18559b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "mkdir: cannot create directory ‘/projects/academic/alexeyak/mohammad/my_repositories/Tutorials_Libra/6_dynamics/2_nbra_workflows/17_active_space_selection/step2_data/new_res’: File exists\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Restricting the active space for S..\n",
+      "Restricting the active space for St..\n",
+      "Restricting the active space for E..\n",
+      "Done with limiting the active space\n",
+      "Your new path_to_npz_files is now: /projects/academic/alexeyak/mohammad/my_repositories/Tutorials_Libra/6_dynamics/2_nbra_workflows/17_active_space_selection/step2_data/new_res\n",
+      "Use the new lowest_orbital: 35 and highest_orbital: 45\n"
+     ]
+    }
+   ],
+   "source": [
+    "params_active_space = {\n",
+    "    'lowest_orbital': 40-19, 'highest_orbital': 40+20, 'num_occ_orbitals': 6, 'num_unocc_orbitals': 5,\n",
+    "    'path_to_npz_files': os.getcwd()+'/step2_data/res', 'logfile_directory': os.getcwd()+'/step2_data/all_logfiles',\n",
+    "    'path_to_save_npz_files': os.getcwd()+'/step2_data/new_res'\n",
+    "}\n",
+    "new_lowest_orbital, new_highest_orbital = step3.limit_active_space(params_active_space)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8ff34c74",
+   "metadata": {},
    "outputs": [],
    "source": [
     "params_mb_sd = {\n",
-    "          'lowest_orbital': 40-19, 'highest_orbital': 40+20, 'num_occ_states': 6, 'num_unocc_states': 5,\n",
+    "          'lowest_orbital': new_lowest_orbital, 'highest_orbital': new_highest_orbital, 'num_occ_states': 6, 'num_unocc_states': 5,\n",
     "          'isUKS': 0, 'number_of_states': 10, 'tolerance': 0.0, 'verbosity': 0, 'use_multiprocessing': True, 'nprocs': 4,\n",
-    "          'is_many_body': False, 'time_step': 1.0, 'es_software': 'cp2k',\n",
-    "          'path_to_npz_files': os.getcwd()+'/step2_data/res',\n",
+    "          'is_many_body': True, 'time_step': 1.0, 'es_software': 'cp2k',\n",
+    "          'path_to_npz_files': params_active_space['path_to_save_npz_files'],\n",
     "          'logfile_directory': os.getcwd()+'/step2_data/all_logfiles',\n",
     "          'path_to_save_sd_Hvibs': os.getcwd()+'/res-sd-6-occ',\n",
     "          'outdir': os.getcwd()+'/res-sd-6-occ', 'start_time': 1200, 'finish_time': 1499, 'sorting_type': 'energy',\n",
@@ -194,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "bd344293",
    "metadata": {},
    "outputs": [],
@@ -209,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0c72299d",
    "metadata": {},
    "outputs": [
@@ -246,19 +279,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "8d85a155",
    "metadata": {},
    "outputs": [],
    "source": [
-    "params_mb_sd.update({'num_occ_states': 7, 'path_to_save_sd_Hvibs':'res-sd-7-occ'})\n",
+    "params_active_space.update({'num_occ_orbitals': 7})\n",
+    "new_lowest_orbital, new_highest_orbital = step3.limit_active_space(params_active_space)\n",
+    "params_mb_sd.update({'lowest_orbital': new_lowest_orbital, 'highest_orbital': new_highest_orbital, \n",
+    "                     'path_to_save_sd_Hvibs':'res-sd-7-occ'})\n",
     "step3.run_step3_sd_nacs_libint(params_mb_sd)\n",
     "clear_output()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d3e85215",
    "metadata": {},
    "outputs": [],
@@ -273,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d0bc309a",
    "metadata": {},
    "outputs": [
@@ -310,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 11,
    "id": "3c018bad",
    "metadata": {},
    "outputs": [],
@@ -318,7 +354,11 @@
     "all_time_overlaps = []\n",
     "num_occ_states = [8,11,12]\n",
     "for num_occ_state in num_occ_states:\n",
-    "    params_mb_sd.update({'num_occ_states': num_occ_state, 'path_to_save_sd_Hvibs':f'res-sd-{num_occ_state}-occ'})\n",
+    "    print('Doing the calculations for:', num_occ_state)\n",
+    "    params_active_space.update({'num_occ_orbitals': num_occ_state})\n",
+    "    new_lowest_orbital, new_highest_orbital = step3.limit_active_space(params_active_space)\n",
+    "    params_mb_sd.update({'lowest_orbital': new_lowest_orbital, 'highest_orbital': new_highest_orbital,\n",
+    "                         'path_to_save_sd_Hvibs':f'res-sd-{num_occ_state}-occ'})\n",
     "    step3.run_step3_sd_nacs_libint(params_mb_sd)\n",
     "    clear_output()\n",
     "    time_overlaps = []\n",
@@ -331,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 12,
    "id": "9cadb38b",
    "metadata": {},
    "outputs": [
@@ -374,12 +414,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "fdd73d5d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "for nocc in [11,12]:\n",
+    "for nocc in [6,7,8,11,12]:\n",
     "    path_to_save_sd_Hvibs = f'res-sd-{nocc}-occ'\n",
     "    istep = 1200\n",
     "    fstep = 1498\n",
@@ -459,7 +499,7 @@
     "    NSTEPS = 1000\n",
     "    #############\n",
     "\n",
-    "    dyn_general = { \"nsteps\":NSTEPS, \"ntraj\":50, \"nstates\":NSTATES, \"dt\":1.0*units.fs2au,\n",
+    "    dyn_general = { \"nsteps\":NSTEPS, \"ntraj\":25, \"nstates\":NSTATES, \"dt\":1.0*units.fs2au,\n",
     "                    \"decoherence_rates\":rates, \"ave_gaps\":gaps,                \n",
     "                    \"progress_frequency\":0.1, \"which_adi_states\":range(NSTATES), \"which_dia_states\":range(NSTATES),\n",
     "                    \"mem_output_level\":2,\n",
@@ -518,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 9,
    "id": "34ff993d",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
After finding the proper number of occupied and unoccupied orbitals from the energy vs time plots, one requires to define new lowest_orbital and highest_orbital values for step 3 or rerun the step 2 from scratch using the new values of lowest_orbital and highest_orbital. By using the `step3.limit_active_space(params)` the user does not need to rerun step 2 nor writing a script to extract the data from step 2 calculations with the new active space for S, St, and E matrices. This function does all and the new tutorial works for many-body basis. Minor changes were required to revise the tutorial but that makes it more flexible and more general.